### PR TITLE
get rid of random checkpoint name

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -283,7 +283,8 @@ public class PendingCheckpoint {
 	
 					return finalizeInternal(metadataHandle, externalPointer);
 				} else {
-					final FileStateHandle metadataHandle = SavepointStore.storeExternalizedCheckpointToHandle(targetDirectory, savepoint);
+					String chkFileName = jobId + "-" + checkpointTimestamp + "-" + checkpointId;
+					final FileStateHandle metadataHandle = SavepointStore.storeExternalizedCheckpointToHandle(targetDirectory, chkFileName, savepoint);
 					final String externalPointer = metadataHandle.getFilePath().toString();
 
 					return finalizeInternal(metadataHandle, externalPointer);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointStore.java
@@ -165,6 +165,19 @@ public class SavepointStore {
 	}
 
 	/**
+	 * Stores the externalized checkpoint metadata file to a state handle.
+	 *
+	 * @param directory Target directory to store savepoint in
+	 * @param savepoint Savepoint to be stored
+	 *
+	 * @return State handle to the checkpoint metadata
+	 * @throws IOException Failures during store are forwarded
+	 */
+	public static <T extends Savepoint> FileStateHandle storeExternalizedCheckpointToHandle(String directory, String fileName, T savepoint) throws IOException {
+		return storeSavepointToHandle(directory, fileName, savepoint);
+	}
+
+	/**
 	 * Stores the savepoint metadata file to a state handle.
 	 *
 	 * @param directory Target directory to store savepoint in

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/ExternalizedCheckpointSettings.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/ExternalizedCheckpointSettings.java
@@ -28,7 +28,7 @@ public class ExternalizedCheckpointSettings implements java.io.Serializable {
 
 	private static final long serialVersionUID = -6271691851124392955L;
 
-	private static final ExternalizedCheckpointSettings NONE = new ExternalizedCheckpointSettings(false, false);
+	private static final ExternalizedCheckpointSettings NONE = new ExternalizedCheckpointSettings(false, false, null);
 
 	/** Flag indicating whether checkpoints should be externalized. */
 	private final boolean externalizeCheckpoints;
@@ -36,9 +36,12 @@ public class ExternalizedCheckpointSettings implements java.io.Serializable {
 	/** Flag indicating whether externalized checkpoints should delete on cancellation. */
 	private final boolean deleteOnCancellation;
 
-	private ExternalizedCheckpointSettings(boolean externalizeCheckpoints, boolean deleteOnCancellation) {
+	private final String externalizedCheckpointDirectory;
+
+	private ExternalizedCheckpointSettings(boolean externalizeCheckpoints, boolean deleteOnCancellation, String externalizedCheckpointDirectory) {
 		this.externalizeCheckpoints = externalizeCheckpoints;
 		this.deleteOnCancellation = deleteOnCancellation;
+		this.externalizedCheckpointDirectory = externalizedCheckpointDirectory;
 	}
 
 	/**
@@ -59,8 +62,17 @@ public class ExternalizedCheckpointSettings implements java.io.Serializable {
 		return deleteOnCancellation;
 	}
 
+	public String getExternalizedCheckpointDirectory() {
+		return externalizedCheckpointDirectory;
+	}
+
+
 	public static ExternalizedCheckpointSettings externalizeCheckpoints(boolean deleteOnCancellation) {
-		return new ExternalizedCheckpointSettings(true, deleteOnCancellation);
+		return new ExternalizedCheckpointSettings(true, deleteOnCancellation, null);
+	}
+
+	public static ExternalizedCheckpointSettings externalizeCheckpoints(boolean deleteOnCancellation, String externalizedCheckpointDirectory) {
+		return new ExternalizedCheckpointSettings(true, deleteOnCancellation, externalizedCheckpointDirectory);
 	}
 
 	public static ExternalizedCheckpointSettings none() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
@@ -70,6 +70,7 @@ public class CheckpointConfig implements java.io.Serializable {
 	/** Cleanup behaviour for persistent checkpoints. */
 	private ExternalizedCheckpointCleanup externalizedCheckpointCleanup;
 
+	private String externalizedCheckpointDirectory;
 	// ------------------------------------------------------------------------
 
 	/**
@@ -253,9 +254,15 @@ public class CheckpointConfig implements java.io.Serializable {
 	 */
 	@PublicEvolving
 	public void enableExternalizedCheckpoints(ExternalizedCheckpointCleanup cleanupMode) {
+		this.externalizedCheckpointDirectory = null;
 		this.externalizedCheckpointCleanup = checkNotNull(cleanupMode);
 	}
 
+	@PublicEvolving
+	public void enableExternalizedCheckpoints(String externalizedCheckpointDirectory, ExternalizedCheckpointCleanup cleanupMode) {
+		this.externalizedCheckpointDirectory = externalizedCheckpointDirectory;
+		this.externalizedCheckpointCleanup = checkNotNull(cleanupMode);
+	}
 	/**
 	 * Returns whether checkpoints should be persisted externally.
 	 *
@@ -275,6 +282,11 @@ public class CheckpointConfig implements java.io.Serializable {
 	@PublicEvolving
 	public ExternalizedCheckpointCleanup getExternalizedCheckpointCleanup() {
 		return externalizedCheckpointCleanup;
+	}
+
+	@PublicEvolving
+	public String getExternalizedCheckpointDirectory() {
+		return externalizedCheckpointDirectory;
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -608,11 +608,16 @@ public class StreamingJobGraphGenerator {
 		ExternalizedCheckpointSettings externalizedCheckpointSettings;
 		if (cfg.isExternalizedCheckpointsEnabled()) {
 			CheckpointConfig.ExternalizedCheckpointCleanup cleanup = cfg.getExternalizedCheckpointCleanup();
+			String externalizedCheckpointDirectory = cfg.getExternalizedCheckpointDirectory();
 			// Sanity check
 			if (cleanup == null) {
 				throw new IllegalStateException("Externalized checkpoints enabled, but no cleanup mode configured.");
 			}
-			externalizedCheckpointSettings = ExternalizedCheckpointSettings.externalizeCheckpoints(cleanup.deleteOnCancellation());
+			if (externalizedCheckpointDirectory == null) {
+				externalizedCheckpointSettings = ExternalizedCheckpointSettings.externalizeCheckpoints(cleanup.deleteOnCancellation());
+			} else {
+				externalizedCheckpointSettings = ExternalizedCheckpointSettings.externalizeCheckpoints(cleanup.deleteOnCancellation(), externalizedCheckpointDirectory);
+			}
 		} else {
 			externalizedCheckpointSettings = ExternalizedCheckpointSettings.none();
 		}


### PR DESCRIPTION
Flink's use a random name for its externalized checkpoint. Currently the checkpoint under the checkpoint root directory looks like:
checkpoint_metadata-2d00588c6398
It makes it very hard to distinguish which file belongs to which flink application.
It also make it impossible to figure out which file belong to which after the flink cluster is destroyed. 

We are going to make the following changes,
1. each of the flink apps can choose to have a dedicated sub folder for its checkpoint
2. each checkpoint will have a timestamp attach to it
3. user need to guarantee the sub folder's name is unique for their flink app

More reading if anyone interested:
https://medium.com/hadoop-noob/flink-externalized-checkpoint-eb86e693cfed